### PR TITLE
BUG/Fix the overwrite of the BOTIUM_CONFIG env var

### DIFF
--- a/bin/botium-cli.js
+++ b/bin/botium-cli.js
@@ -10,10 +10,10 @@ const handleConfig = (argv) => {
     require('debug').enable('botium*')
   }
 
-  if (argv.config || argv.c) {
-    process.env.BOTIUM_CONFIG = argv.config || argv.c
-    debug(`Using Botium configuration file ${process.env.BOTIUM_CONFIG}`)
+  if (!process.env.BOTIUM_CONFIG) {
+    process.env.BOTIUM_CONFIG = argv.config
   }
+  debug(`Using Botium configuration file ${process.env.BOTIUM_CONFIG}`)
 
   const envConvoDirs = Object.keys(process.env).filter(e => e.startsWith('BOTIUM_CONVOS')).map(e => process.env[e]).filter(e => e)
   if (envConvoDirs && envConvoDirs.length > 0) {
@@ -50,6 +50,7 @@ yargsCmd.usage('Botium CLI\n\nUsage: $0 [options]') // eslint-disable-line
   .command(require('../src/agent'))
   .option('verbose', {
     alias: 'v',
+
     describe: 'Enable verbose output (also read from env variable "BOTIUM_VERBOSE" - "1" means verbose)',
     default: false
   })
@@ -61,6 +62,7 @@ yargsCmd.usage('Botium CLI\n\nUsage: $0 [options]') // eslint-disable-line
   })
   .option('config', {
     alias: 'c',
+    envPrefix: 'BOTIUM_CONFIG',
     describe: 'Path to the Botium configuration file (also read from env variable "BOTIUM_CONFIG")',
     nargs: 1,
     default: './botium.json'

--- a/bin/botium-cli.js
+++ b/bin/botium-cli.js
@@ -50,7 +50,6 @@ yargsCmd.usage('Botium CLI\n\nUsage: $0 [options]') // eslint-disable-line
   .command(require('../src/agent'))
   .option('verbose', {
     alias: 'v',
-
     describe: 'Enable verbose output (also read from env variable "BOTIUM_VERBOSE" - "1" means verbose)',
     default: false
   })


### PR DESCRIPTION
  - Declare env var in the yargs template
  - Assign the conf parameter value to the BOTIUM_CONFIG env var only when the environment variable does not exist. 

FIX  #147